### PR TITLE
DIANNv2  parquet format

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The description of the parameters is the following:
 - `contrast`: name of the column present in experiment design file used in the model. (default is Group)
 - `aggr_method`: summaration method used [medianPolish robustSummary() , colMeans(), colMedians(), base::colSums()]
 - `normalization`: normalization method [ sum, max, center.mean, center.median", div.mean, div.median", diff.meda, ⁠quantiles⁠, ⁠quantiles.robust⁠ , vsn]
-- `Proteotypic`: include only proteotypic peptides (Boolen: TRUE / FALSE )
+- `Proteotypic`: include only proteotypic peptides (Boolean: TRUE / FALSE )
 - `pep_per_prot`: number of peptides per proteins
 - `nNonZero`: min percentage of samples with non missing value (used along with `filtPerGroup`)
 - `comparisons`: list of the comparison to use
@@ -58,6 +58,7 @@ The description of the parameters is the following:
 - `PCA_comparison`: list of cofounder values to use in PCA analysis
 - `quantitatve_features`: quantitative feature column to use
 - `filtPerGroup`: filtering of the NaN value based on `nNonZero` value applied per group (TRUE) or along all the sample (FALSE)
+- `mbr`: in case of MBR activated in DIA-NN, use Global.Q-value and Global.PG.Q-values to select precursor (Boolean: TRUE / FALSE )
 
 Parameters can be also given as R list as showed in `Run_Template_FromR.R` and `Run_Template_FromR_peptide.R`.
 

--- a/Template_DIA-NN_v1.qmd
+++ b/Template_DIA-NN_v1.qmd
@@ -252,7 +252,9 @@ if (check_confounder_list$status == 1){
    base_name_sample =  basename(filename) ) 
     
   }
-  
+  # samplenames <- tibble(
+  # base_name_sample = names(a_wide )[str_which(names(a_wide ), paste0('\\','CMB'))]  ) 
+
   
   samplenames <- samplenames %>% left_join(  design %>% dplyr::select(run, sample) , join_by(base_name_sample ==  run) )
  

--- a/Template_DIA-NN_v1.qmd
+++ b/Template_DIA-NN_v1.qmd
@@ -47,6 +47,8 @@ params:
   quantitatve_features: "Precursor.Quantity"
   filtPerGroup: TRUE
   mbr: FALSE
+  wildstr_run: "CMB-"
+  DIANN_ver2: FALSE 
 ---
 
 <!-- <style> -->
@@ -108,7 +110,7 @@ params:
 source('utils_function.R')
 
 required_packages = c("QFeatures","msqrob2","readxl","SummarizedExperiment","visdat","ggrepel", "dplyr","tidyverse","magrittr","here","tidyr","plotly","DT","tibble","MSnbase",
-                    "factoextra","hrbrthemes","gridExtra","UpSetR",'logger', 'scales','pander','heatmaply','GGally')
+                    "factoextra","hrbrthemes","gridExtra","UpSetR",'logger', 'scales','pander','heatmaply','GGally','arrow')
 #print(required_packages)
 check_dependencies(required_packages)
 
@@ -190,23 +192,45 @@ Reading DIA data from **`r basename(params$input_file)`** using *`r params$quant
 
 ```{r import data}
 
-  log_info('Reading Data...')
-  data <- read.csv(params$input_file,sep='\t')
+  if (params$DIANN_ver2){
+     log_info('Reading Data PARQUET format...')
+     data <- read_parquet(params$input_file)
+     
+  }else{
+     log_info('Reading Data TSV format...')
+     data <- read.csv(params$input_file,sep='\t')
+  }
+ 
   ## deal csv  with different separated values 
   L <- readLines(params$design_file, n = 1)
   if (grepl(";", L)) design <- read.csv2(params$design_file) else design <- read.csv(params$design_file)
 
-  checkDIANN<-check_DIANN_report(data, q_feature=params$quantitatve_features)
+  
+  
+  checkDIANN <- check_DIANN_report(data, q_feature=params$quantitatve_features)
     
   if (checkDIANN$status == 1 ) {
     stop(checkDIANN$error)
     } 
   
-  dfMsqrob <- dfToWideMsqrob( data, precursorquan = params$quantitatve_features, mbr = params$mbr)
+  dfMsqrob <- dfToWideMsqrob_20( data, precursorquan = params$quantitatve_features, mbr = params$mbr)
+  
+  if (params$DIANN_ver2){
+    log_info('Retrieve Protein description(ver > 2.0)...')
+
+    prt_desc <- read.csv( file.path(dirname(params$input_file),'report.protein_description.tsv'),sep="\t"  )
+    
+    dfMsqrob<- dfMsqrob %>% mutate(app = sapply(str_split(Protein.Names, ";"), function(x) ifelse(length(x) > 0, x[1], NA))) %>% 
+       left_join( prt_desc %>% select(Protein.Name,Description) , 
+                  join_by(app == Protein.Name)) %>% 
+      select(- app) %>% rename( First.Protein.Description =  Description   ) # filter(is.na(Description)) 
+    }
+  
+
  
   result_check <- check_design_data(dfMsqrob,design) 
   
-  if (result_check$status == 1 |  is.na(result_check$type_raw) ){
+  if (result_check$status == 1  ){
     stop(result_check$error)
   }  
   
@@ -231,39 +255,29 @@ if (check_groups$status == 1){
 
   if (all(params$confounder_list != '')) {
   check_confounder_list<-checkConfounder(confounder= params$confounder_list, colsDesign=colnames(design))
-if (check_confounder_list$status == 1){
-    stop(check_confounder_list$error)
-}
+    if (check_confounder_list$status == 1){
+        stop(check_confounder_list$error)
+    }
   }
 
-  
-  if ( .Platform$OS.type == "unix" ){
-    samplenames <- tibble(
-   filename = gsub('\\\\','/' ,names(dfMsqrob)[str_which(names(dfMsqrob), result_check$type_raw)]), 
-   base_name_sample =  basename(filename) ) 
-  
-  }else{
- #    samplenames <- tibble(
-#   filename = names(dfMsqrob)[str_which(names(dfMsqrob), result_check$type_raw)], 
- #  base_name_sample =  basename(filename) ) 
-    
-  samplenames <- tibble(
-  filename = names(dfMsqrob)[str_which(names(dfMsqrob), paste0('\\',result_check$type_raw))], 
-   base_name_sample =  basename(filename) ) 
-    
-  }
-  # samplenames <- tibble(
-  # base_name_sample = names(a_wide )[str_which(names(a_wide ), paste0('\\','CMB'))]  ) 
 
+  #  params$wildstr_run
   
+   samplenames <- tibble(
+     base_name_sample = names(dfMsqrob)[str_which(names(dfMsqrob),   'CMB-' )  ]
+      ) 
+    
+ 
   samplenames <- samplenames %>% left_join(  design %>% dplyr::select(run, sample) , join_by(base_name_sample ==  run) )
- 
- 
-  names(dfMsqrob)[str_which(names(dfMsqrob), paste0('\\',result_check$type_raw))] <- samplenames$sample
+  # debugging
+  # names(a_wide)[str_which(names(a_wide), paste0('\\','CMB-'))] <- samplenames$sample
+  # names(b_wide)[str_which(names(b_wide), paste0('\\','_DIA'))] <- samplenames$sample
+
+
+  names(dfMsqrob)[str_which(names(dfMsqrob),  'CMB-' ) ] <- samplenames$sample
  
   diann_colname <- c("Precursor.Id" , "Modified.Sequence","Stripped.Sequence","Protein.Group",
   "Protein.Ids","Protein.Names","Genes","Proteotypic","First.Protein.Description")
- 
 
 ```
 
@@ -275,7 +289,7 @@ if (check_confounder_list$status == 1){
 
  pe <- readQFeatures( dfMsqrob,
                      fnames = "Precursor.Id",
-                     ecol =  str_detect(names(dfMsqrob), paste(diann_colname, collapse = "|"), negate=TRUE) ,
+                     ecol =  str_detect(names(dfMsqrob), paste( diann_colname , collapse = "|"), negate=TRUE) ,
                      name = "precursor")
 
 

--- a/utils_function.R
+++ b/utils_function.R
@@ -203,6 +203,69 @@ dfToWideMsqrob <- function(data, precursorquan, mbr) {
  
 }
 
+######-----dfToWideMsqrob_20-------------------------
+#' @author Andrea
+#' dfToWideMsqrob
+#' This function after some quality check makes and filtering of some columns 
+#' It makes  wide version of the DIA-NN result using the precursorquant columns
+#' @param data frame containing the DIA-NN report data
+#' @param precursorquan: columns to use to pivot into a wide format 
+#' 
+#' @return status : A data frame of DIA-NN in a wide format 
+dfToWideMsqrob_20 <- function(data, precursorquan, mbr) {
+  
+  if (mbr == TRUE) {
+    
+    data %>%
+      filter(
+        Global.PG.Q.Value <= 0.01 &
+          Global.Q.Value <= 0.01 &
+          Precursor.Id != "" & 
+          .data[[precursorquan]] > 0
+      ) %>%
+      dplyr::select(
+        Run, 
+        Precursor.Id, 
+        Modified.Sequence, 
+        Stripped.Sequence, 
+        Protein.Group,
+        Protein.Ids, 
+        Protein.Names, 
+        Genes, 
+        Proteotypic,
+        .data[[precursorquan]]
+      ) %>%
+      tidyr::pivot_wider(
+        names_from = Run,
+        values_from = .data[[precursorquan]]
+      )
+    
+  }else{   data %>%
+      filter(
+        PG.Q.Value <= 0.01 &
+          Q.Value <= 0.01 &
+          Precursor.Id != "" & 
+          .data[[precursorquan]] > 0
+      ) %>%
+      dplyr::select(
+        Run, 
+        Precursor.Id, 
+        Modified.Sequence, 
+        Stripped.Sequence, 
+        Protein.Group,
+        Protein.Ids, 
+        Protein.Names, 
+        Genes, 
+        Proteotypic,
+        .data[[precursorquan]]
+      ) %>%
+      tidyr::pivot_wider(
+        names_from = Run,
+        values_from = .data[[precursorquan]]
+      ) }
+  
+}
+
 ######--- DEP_volcano----------------------------
 #' @author Andrea Argentini 
 #' DEP_volcano

--- a/utils_function.R
+++ b/utils_function.R
@@ -61,7 +61,7 @@ check_DIANN_report <- function  (data_ , q_feature){
  
 check_design_data  <- function  (data_ , design){
   status <- 0
-  type_raw <- NA
+  #type_raw <- NA
   error <-
     
   data_sample <- colnames(data_)[10:length(colnames(data_))]
@@ -72,12 +72,12 @@ check_design_data  <- function  (data_ , design){
     #error <-  paste( c('Design file not recognized. It should contains at least the following columns:', paste(min_col_need_design,sep=' ')) ,sep=',' )
     error <-  capture.output(cat ( 'Design file not recognized. It should contains at least the following columns:',min_col_need_design,sep='\n\n' ))
     status <- 1
-    return(list(status=status, type_raw=type_raw,error=error))
+    return(list(status=status ,error=error))
   }
   
-  type_raw <- str_match(data_sample,'\\..*')[,1][1]
+  #type_raw <- str_match(data_sample,'\\..*')[,1][1]
   
-  return(list(status=status, type_raw=type_raw))
+  return(list(status=status))
   
 }
 
@@ -102,7 +102,8 @@ check_length_design_data  <- function  (data_ , design){
   message <- ''
   
   data_sample <- colnames(data_)[10:length(colnames(data_))]
-  d_sample <- design %>% dplyr::select(filename) %>% pull()
+  ## filename does not exist 
+  d_sample <- design %>% dplyr::select(run) %>% pull()
   
   
   if (length(data_sample) < length(d_sample)){
@@ -117,12 +118,13 @@ check_length_design_data  <- function  (data_ , design){
     status <- 1
     return(list(status=status,error=error,message=message))	
   }
-  
+  ### pay attention here 
   if (length(data_sample) > length(d_sample)){
     status <- 2
     dfSample<- dfMsqrob[,(colnames(dfMsqrob)%in% d_sample)]
+    ## "First.Protein.Description" on hold for the moment
     df  <- cbind(dfMsqrob[, c("Precursor.Id" , "Modified.Sequence","Stripped.Sequence","Protein.Group",
-                        "Protein.Ids","Protein.Names","Genes","Proteotypic","First.Protein.Description")], dfSample)
+                        "Protein.Ids","Protein.Names","Genes","Proteotypic")], dfSample)
     message <- 'Number of samples in DIA-NN is bigger than number of samples in design file.'
     return(list(status=status, error = error, message=message , data_ = df))
   }else{
@@ -140,6 +142,8 @@ check_length_design_data  <- function  (data_ , design){
 ######-----dfToWideMsqrob-------------------------
 #' @author Leander 
 #' dfToWideMsqrob
+#' This is not used anymore, should be remove soon. 
+#' MAching od sample name with run now is dobe using run columns
 #' This function after some quality check makes and filtering of some columns 
 #' It makes  wide version of the DIA-NN result using the precursorquant columns
 #' @param data frame containing the DIA-NN report data


### PR DESCRIPTION
This patch adds fully compatibility for parquet format  from DIANN v 2.0.
- the matching between sample name and run now is done using the run information in the metadata and  it is  just the base name of the raw file without  its extension. (a.raw -> a )
- For DIA-NN v 2.0+ , in the input folder should be also available also the protein report file. 